### PR TITLE
A proposal for the vim-slime plugin framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,47 @@ easy/hard it would be to keep target/language plugins outside of this codebase.
 
 ## Proposed plugin structure
 
-A simple, stupid plugin that echoes the text being sent could have the following
-structure :
+Vim-slime needs a way to configure, and a way to send text. Configuration is
+done through a vim function, and sending through either a `system` call, or a
+vim function.
 
+### Example of using a simple `system` call.
+
+In your configuration set 
+
+```vimscript
+let slime_target_send="cat >> foo.txt"
+```
+
+You've effectively setup a vim-slime plugin that writes everything it's sent to
+'foo.txt' ! vim-slime will send any text it's supposed to send to `cat`'s STDIN.
+
+### Example of using a simple `system` call, but with some configuration.
+
+Let's keep going with the previous plugin, but this time we want a bit of
+configuration. In `vim-slime` configuration is made on a per-buffer basis. We
+need to do that using a vim function. In you configuration file, you can add the
+following :
+
+```vimscript
+function! SlimeTargetConfig()
+  if !exists("b:slime_config")
+    let b:slime_config = ""
+  endif
+  let b:slime_config = input("Target file name :", b:slime_config) 
+endfunction
+```
+
+and replace the target command with :
+
+```vimscript
+slime_target_send="bash -c 'cat >> $CONFIG'"
+```
+
+(the extra `bash -c` statement is needed to allow access to the $CONFIG
+environment variable set by vim-slime. See [here](https://unix.stackexchange.com/questions/126938/why-is-setting-a-variable-before-a-command-legal-in-bash))
+
+### Example of a tiny bit more evolved plugin, using vim functions.
 ```
 .
 ├── autoload
@@ -31,4 +69,11 @@ endfunction
 function! slime_echo#send(config, text)
   echo a:text
 endfunction
+```
+
+Then in your configuration file :
+
+```vimscript
+let SlimeTargetConfig=function("slime_wezterm#config")
+let SlimeTargetSend=function("slime_wezterm#send")
 ```

--- a/README.md
+++ b/README.md
@@ -4,3 +4,31 @@ vim-slime-ext-plugins
 A "fork" of [vim-slime](https://github.com/jpalardy/vim-slime) to see how
 easy/hard it would be to keep target/language plugins outside of this codebase.
 
+## Proposed plugin structure
+
+A simple, stupid plugin that echoes the text being sent could have the following
+structure :
+
+```
+.
+├── autoload
+│   └── slime_echo.vim
+├── LICENSE
+├── plugin
+│   └── slime-echo.vim
+└── README.md
+```
+
+With `autoload/slime_echo.vim` being
+
+```vimscript
+function! slime_echo#config()
+  if !exists("b:slime_config['echo']")
+    let b:slime_config["echo"] = {"foo": "useless configuration"}
+  end
+endfunction
+
+function! slime_wezterm#send(config, text)
+  echo a:text
+endfunction
+```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ function! slime_echo#config()
   end
 endfunction
 
-function! slime_wezterm#send(config, text)
+function! slime_echo#send(config, text)
   echo a:text
 endfunction
 ```

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -3,7 +3,8 @@
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 function! s:TargetSend(config, text)
-  let output = system("CONFIG=" . shellescape(a:config) . " " . g:slime_target_send, a:text)
+  let TargetSend = function(g:slime_target . "#send")
+  let output = TargetSend(a:config, a:text)
   if v:shell_error
     echoerr output
   endif
@@ -13,12 +14,12 @@ function! s:TargetConfig() abort
   if exists("b:slime_config")
     return b:slime_config
   end
-  let output = system(g:slime_target_config)
+  let TargetFunction = function(g:slime_target . "#config")
+  let output = TargetFunction()
   if v:shell_error
     echoerr output
     return ""
   endif
-  let b:slime_config = output
   return b:slime_config
 endfunction
 
@@ -60,6 +61,16 @@ function! s:SlimeRestoreCurPos()
     call winrestview(s:cur)
     unlet s:cur
   endif
+endfunction
+
+function! slime#send_range(startline, endline) abort
+  call s:TargetConfig()
+
+  let rv = getreg('"')
+  let rt = getregtype('"')
+  silent exe a:startline . ',' . a:endline . 'yank'
+  call slime#send(@")
+  call setreg('"', rv, rt)
 endfunction
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -8,6 +8,7 @@ let g:loaded_slime = 1
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 command -bar -nargs=0 SlimeConfig call slime#config()
+command -range -bar -nargs=0 SlimeSend call slime#send_range(<line1>, <line2>)
 
 noremap <SID>Operator :<c-u>call slime#store_curpos()<cr>:set opfunc=slime#send_op<cr>g@
 


### PR DESCRIPTION
Hi @jpalardy ! I like the idea of having a small vim-slime core.

I messed around with what's inside this repo, and thought that maybe we could do things a bit differently, having vim-slime using an external vim plugin to send the actual data.

`TargetSend` and `TargetConfig` now look for a `g:slime_target`
configuration variable, and try to use respectively the
`function(g:slime_target . "#send")` and `function(g:slime_target . "#config")` functions.

This means if you want to create e.g. a wezterm target, you can create a
wezterm plugin with a `slime_wezterm#config()` and a
`slime_wezterm#send(config, text)` functions. You can then simply set
the `g:slime_target` variable to "slime_wezterm".

I created such a target plugin [here](https://github.com/Klafyvel/vim-slime-ext-wezterm), and you can use it with the following packer configuration (although I guess any package manager is fine, as long as the target plugin autoload functions are available to vim-slime) :

```lua
use {
    'Klafyvel/vim-slime-ext-plugins',
    requires = 'Klafyvel/vim-slime-ext-wezterm',
    config=function ()
      vim.cmd([[
        nmap <leader>cv <Plug>SlimeConfig
      ]])
      vim.g.slime_target = "slime_wezterm"
    end
  }
```