### PR TITLE
Code restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ function! SlimeFooPluginConfig(config)
 endfunction
 ```
 
-In case your plugin does not need configuration, you can use the `slime#noop` convenience at the registration step.
+In case your plugin does not need configuration, you can use the `slime#noop` convenience function at the registration step.
 
 ### Sending the data
 

--- a/README.md
+++ b/README.md
@@ -4,97 +4,55 @@ vim-slime-ext-plugins
 A "fork" of [vim-slime](https://github.com/jpalardy/vim-slime) to see how
 easy/hard it would be to keep target/language plugins outside of this codebase.
 
-## Proposed plugin structure
+This fork uses plugins to send data to its targets.
 
-Vim-slime needs a way to configure, and a way to send text. Configuration is
-done through a vim function, and sending through either a `system` call, or a
-vim function.
+## Plugin structure
 
-### Example of using a simple `system` call.
+Vim-slime needs a way to configure, and a way to send text. This is
+done through vim functions that you or your plugin must declare.
 
-In your configuration set 
+### Example of using a simple plugin
 
-```vimscript
-let slime_target_send="cat >> foo.txt"
-```
+In this example, we are going to write a plugin that sends the text it receives to a file `foo.txt`. We need to define a function for plugin configuration, and another for handling the data.
 
-You've effectively setup a vim-slime plugin that writes everything it's sent to
-'foo.txt' ! vim-slime will send any text it's supposed to send to `cat`'s STDIN.
+### Configuration
 
-### Example of using a simple `system` call, but with some configuration.
-
-Let's keep going with the previous plugin, but this time we want a bit of
-configuration. In `vim-slime` configuration is made on a per-buffer basis. We
-need to do that using a vim function. In you configuration file, you can add the
-following :
+The configuration function takes the current configuration in parameter and must return the updated configuration. For our example, one could write the following :
 
 ```vimscript
-function! SlimeSnitchConfig()
-  if !exists("b:slime_config['slime_snitch']")
-    let b:slime_config["slime_snitch"] = "snitch.txt"
+function! SlimeFooPluginConfig(config)
+  if !exists("a:config['foo']")
+    let a:config["foo"] = {"file": "foo.txt"}
   end
-  let b:slime_config["slime_snitch"] = input("Snitch filename : ", b:slime_config["slime_snitch"])
+  let a:config["foo"]["file"] = input("Target file: ", a:config["foo"]["file"])
+  return a:config
 endfunction
 ```
 
-then replace the target command with (the extra `bash -c` statement is needed to allow access to the $CONFIG
-environment variable set by vim-slime. See
-[here](https://unix.stackexchange.com/questions/126938/why-is-setting-a-variable-before-a-command-legal-in-bash))
-:
-```vimscript
-let slime_target_send = "bash -c 'tee $(echo $CONFIG | jq -r .slime_snitch)'"
-```
+In case your plugin does not need configuration, you can use the `slime#noop` convenience at the registration step.
 
-and register your configuration function (note that this is a list with one
-element):
-```vimscript
-let slime_target_config = [function("SlimeSnitchConfig")]
-```
+### Sending the data
 
-
-### Example of a tiny bit more evolved plugin, using vim functions.
-```
-.
-├── autoload
-│   └── slime_echo.vim
-├── LICENSE
-├── plugin
-│   └── slime-echo.vim
-└── README.md
-```
-
-With `autoload/slime_echo.vim` being
+This is the function that will actually do the work. Its paramters are the configuration and the text to send. 
 
 ```vimscript
-function! slime_echo#config()
-  if !exists("b:slime_config['echo']")
-    let b:slime_config["echo"] = {"foo": "useless configuration"}
-  end
-endfunction
-
-function! slime_echo#send(config, text)
-  echo a:text
-  return a:text
+function! SlimeFooPluginSend(config, text)
+  let l:file = a:config["foo"]["file"]
+  return system("cat >> " . shellescape(file), a:text) 
 endfunction
 ```
 
-Then in your configuration file :
+### Registering the plugin
+
+Vim-slime looks for the configuration function and the target function in two variables : `slime_target_send` and `slime_target_config`. Note that these variables can be defined globally or on a per-buffer lever. The variable at buffer level takes precedence. In your configuration file, you can simply add :
 
 ```vimscript
-let slime_target_config=[function("slime_echo#config")]
-let slime_target_send=[function("slime_echo#send")]
+let g:slime_target_send="SlimeFooPluginSend"
+let g:slime_target_config="SlimeFooPluginConfig"
 ```
 
-### Example of chaining plugins.
+Remember that you can use `slime#noop` here if your plugin does not need any configuration.
 
-vim-slime is capable of chaining plugins. This is done by providing multiple functions
-and/or strings in the `slime_target_send` list. The output of each function or
-shell command is fed to the next. This allows plugins to edit the text that is
-being sent by vim-slime, or to send the same text at different locations. For
-example, one could chain the two previous plugins by simply using the following
-configuration :
+## Vim-slime documentation
 
-```vimscript
-let slime_target_config=[function("SlimeSnitchConfig"), function("slime_wezterm#config")]
-let slime_target_send=["bash -c 'tee $(echo $CONFIG | jq -r .slime_snitch)'", function("slime_wezterm#send")]
-```
+The complete documentation is available with `:help vim-slime`.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,47 @@ easy/hard it would be to keep target/language plugins outside of this codebase.
 
 ## Proposed plugin structure
 
-A simple, stupid plugin that echoes the text being sent could have the following
-structure :
+Vim-slime needs a way to configure, and a way to send text. Configuration is
+done through a vim function, and sending through either a `system` call, or a
+vim function.
 
+### Example of using a simple `system` call.
+
+In your configuration set 
+
+```vimscript
+let slime_target_send="cat >> foo.txt"
+```
+
+You've effectively setup a vim-slime plugin that writes everything it's sent to
+'foo.txt' ! vim-slime will send any text it's supposed to send to `cat`'s STDIN.
+
+### Example of using a simple `system` call, but with some configuration.
+
+Let's keep going with the previous plugin, but this time we want a bit of
+configuration. In `vim-slime` configuration is made on a per-buffer basis. We
+need to do that using a vim function. In you configuration file, you can add the
+following :
+
+```vimscript
+function! SlimeTargetConfig()
+  if !exists("b:slime_config")
+    let b:slime_config = ""
+  endif
+  let b:slime_config = input("Target file name :", b:slime_config) 
+endfunction
+```
+
+and replace the target command with :
+
+```vimscript
+slime_target_send="bash -c 'cat >> $CONFIG'"
+```
+
+(the extra `bash -c` statement is needed to allow access to the $CONFIG
+environment variable set by vim-slime. See [here](https://unix.stackexchange.com/questions/126938/why-is-setting-a-variable-before-a-command-legal-in-bash))
+
+### Example of a tiny bit more evolved plugin, using vim functions.
 ```
 .
 ├── autoload
@@ -31,4 +69,11 @@ endfunction
 function! slime_echo#send(config, text)
   echo a:text
 endfunction
+```
+
+Then in your configuration file :
+
+```vimscript
+let SlimeTargetConfig=function("slime_wezterm#config")
+let SlimeTargetSend=function("slime_wezterm#send")
 ```

--- a/README.md
+++ b/README.md
@@ -4,3 +4,31 @@ vim-slime-ext-plugins
 A "fork" of [vim-slime](https://github.com/jpalardy/vim-slime) to see how
 easy/hard it would be to keep target/language plugins outside of this codebase.
 
+## Proposed plugin structure
+
+A simple, stupid plugin that echoes the text being sent could have the following
+structure :
+
+```
+.
+├── autoload
+│   └── slime_echo.vim
+├── LICENSE
+├── plugin
+│   └── slime-echo.vim
+└── README.md
+```
+
+With `autoload/slime_echo.vim` being
+
+```vimscript
+function! slime_echo#config()
+  if !exists("b:slime_config['echo']")
+    let b:slime_config["echo"] = {"foo": "useless configuration"}
+  end
+endfunction
+
+function! slime_wezterm#send(config, text)
+  echo a:text
+endfunction
+```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ function! slime_echo#config()
   end
 endfunction
 
-function! slime_wezterm#send(config, text)
+function! slime_echo#send(config, text)
   echo a:text
 endfunction
 ```

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -15,8 +15,7 @@ endfunction
 function! s:TargetSend(config, text)
   let b:slime_target_send = s:resolve("b:slime_target_send", "g:slime_target_send")
   if b:slime_target_send is v:null
-    echoerr "slime_target_send is not defined"
-    return
+    throw "slime_target_send is not defined"
   endif
   call function(b:slime_target_send)(a:config, a:text)
 endfunction
@@ -24,7 +23,7 @@ endfunction
 function! s:TargetConfig(config) abort
   let b:slime_target_config = s:resolve("b:slime_target_config", "g:slime_target_config")
   if b:slime_target_config is v:null
-    return v:null
+    throw "slime_target_config is not defined"
   endif
   return function(b:slime_target_config)(a:config)
 endfunction
@@ -107,3 +106,7 @@ function! slime#reconfig() abort
   return slime#config()
 endfunction
 
+" helper function for empty configs
+function! slime#noop(...)
+  return {}
+endfunction

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -69,8 +69,6 @@ function! s:SlimeRestoreCurPos()
 endfunction
 
 function! slime#send_range(startline, endline) abort
-  call s:TargetConfig()
-
   let rv = getreg('"')
   let rt = getregtype('"')
   silent exe a:startline . ',' . a:endline . 'yank'

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -3,7 +3,8 @@
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 function! s:TargetSend(config, text)
-  let output = system("CONFIG=" . shellescape(a:config) . " " . g:slime_target_send, a:text)
+  let TargetSend = function(g:slime_target . "#send")
+  let output = TargetSend(a:config, a:text)
   if v:shell_error
     echoerr output
   endif
@@ -13,12 +14,12 @@ function! s:TargetConfig() abort
   if exists("b:slime_config")
     return b:slime_config
   end
-  let output = system(g:slime_target_config)
+  let TargetFunction = function(g:slime_target . "#config")
+  let output = TargetFunction()
   if v:shell_error
     echoerr output
     return ""
   endif
-  let b:slime_config = output
   return b:slime_config
 endfunction
 
@@ -60,6 +61,16 @@ function! s:SlimeRestoreCurPos()
     call winrestview(s:cur)
     unlet s:cur
   endif
+endfunction
+
+function! slime#send_range(startline, endline) abort
+  call s:TargetConfig()
+
+  let rv = getreg('"')
+  let rt = getregtype('"')
+  silent exe a:startline . ',' . a:endline . 'yank'
+  call slime#send(@")
+  call setreg('"', rv, rt)
 endfunction
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -1,0 +1,127 @@
+*slime.txt*   Grab some text and "send" it to a REPL session.
+
+Author:  Jonathan Palardy                                       *slime-author*
+License: Same terms as Vim itself (see |license|)
+
+This plugin is only available if 'compatible' is not set.
+
+==============================================================================
+                                                                       *slime*
+Grab some text and "send" it to a REPL session.
+
+	VIM --> vim-slime --> REPL~
+
+Presumably, your session contains a REPL, maybe Clojure, R or python. If you
+can type text into it, vim-slime can send text to it.
+
+The reason you're doing this? Because you want the benefits of a REPL and the
+benefits of using Vim (familiar environment, syntax highlighting, persistence
+...).
+
+1. Slime Usage...................................................|slime-usage|
+2. Plugin Configuration...........................|slime-plugin-configuration|
+3. Available Plugins...........................................|slime-plugins|
+4. Slime Configuration...................................|slime-configuration|
+5. Slime functions...........................................|slime-functions|
+
+==============================================================================
+1. Slime Usage                                                   *slime-usage*
+
+                                                  *CTRL-C_CTRL-C* *<c-c><c-c>*
+<c-c><c-c>		      Send the current paragraph text to REPL. Slime will prompt
+                    for configuration if slime is not configured for the
+                    current buffer.
+
+                                              *v_CTRL-C_CTRL-C* *v_<c-c><c-c>*
+{Visual}<c-c><c-c>	Send highlighted text to REPL.
+
+                                                           *CTRL-C_v* *<c-c>v*
+                                                                *:SlimeConfig*
+<c-c>v			        Setup slime. You will be prompted for information
+:SlimeConfig        regarding plugin configuration if needed.
+
+                                                                  *:SlimeSend*
+:<range>SlimeSend	  Send a [range] of lines to REPL. If no range is provided
+                    the current line is sent.
+
+==============================================================================
+2. Plugin Configuration                           *slime-plugin-configuration*
+
+Vim-slime needs a plugin to actually send your code to the REPL. Several
+plugins are available, see |slime-plugins|. 
+
+A plugin should expose at least one target function that will be used by
+vim-slime to send data to the REPL. The signature must be :
+
+`MyTargetFunction(config, text)`
+
+With `config` being the configuration variable and `text` the text which is to
+be sent. It is a good practice that `config` is a dictionary, and that a
+plugins register their configuration in `config["myplugin"]`. Vim-slime takes
+care to initialize the configuration by calling the defined configuration
+function. Such a function must have the following signature :
+
+`MyConfigFunction(config)`
+
+And return the modified configuration.
+
+Both target and configuration functions must be declared to vim-slime using
+|b:slime_target_send| or |g:slime_target_send| and |b:slime_target_config| and
+|g:slime_target_config| respectively. The buffer variable takes precedence
+over the global variable, so you can use different plugins for different
+buffers. 
+
+Note: If your plugin does not need any configuration, you can register
+`slime#noop` instead of your configuration function.
+
+
+==============================================================================
+3. Available Plugins                                           *slime-plugins*
+
+	*Todo	list known plugins here an links to their repositories.
+
+==============================================================================
+4. Slime Configuration                                   *slime-configuration*
+
+Global Variables~
+*g:slime_target_send*       |string| used to register the plugin's target 
+                          function
+*g:slime_target_config*     |string| used to register the plugin's configuration
+                          function
+*g:slime_no_mappings*     If set, disable the default mappings.
+
+Buffer Variables~
+*b:slime_target_send*       Same as |g:slime_target_send|, but takes precedence
+                          over it.
+*b:slime_target_config*     Same as |g:slime_target_config| but takes
+                          precedence over it.
+Mappings~
+
+Note: The default mappings can be disabled using |g:slime_no_mappings|.
+
+*<Plug>SlimeRegionSend*       Send text in visual or select mode.
+*<Plug>SlimeParagraphSend*    Send the current paragraph.
+*<Plug>SlimeConfig*           Trigger plugin configuration.
+
+==============================================================================
+5. Slime functions                                           *slime-functions*
+
+Vim-slime defines a public interface that you can use.
+
+slime#send({text})                                              *slime#send()*
+          Send the given {text} to the target.
+
+slime#config()                                                *slime#config()*
+          Trigger vim-slime configuration and return the configuration. If 
+          vim-slime is already configured for the current buffer, return the
+          current configuration.
+
+slime#reconfig()                                            *slime#reconfig()*
+          Force vim-slime reconfiguration. Erase current buffer configuration
+          and call |slime#config()|.
+
+slime#noop(...)                                                 *slime#noop()*
+          Do nothing. Useful to feed to |g:slime_target_config| when a plugin
+          does not need any configuration.
+
+vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -8,6 +8,7 @@ let g:loaded_slime = 1
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 command -bar -nargs=0 SlimeConfig call slime#config()
+command -range -bar -nargs=0 SlimeSend call slime#send_range(<line1>, <line2>)
 
 noremap <SID>Operator :<c-u>call slime#store_curpos()<cr>:set opfunc=slime#send_op<cr>g@
 


### PR DESCRIPTION
What's included:
- variable-resolution logic (local, global ...)
- `slime_send_target` mandatory
- `slime_config_target` optional (this could be more explicit as `slime#noop` .... :thinking: )

using this config while developing:

```vimscript
function SendToTmux(config, text)
  echom "sending: " . a:text . "--" . a:config
endfunction

let g:slime_target_send = "SendToTmux"
```

What's missing:
- updated README (not until we're happy with the code)
- more comments, as necessary
- array of filters (to be resolved and invoked before target)

cc: @Klafyvel 